### PR TITLE
Switch to Corepack instead of Yarn APT to avoid GPG errors

### DIFF
--- a/devcontainer.json.sample
+++ b/devcontainer.json.sample
@@ -46,7 +46,7 @@
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {
-      "installYarnUsingApt": false,
+      "installYarnUsingApt": false
     },
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
   },

--- a/devcontainer.json.sample
+++ b/devcontainer.json.sample
@@ -45,7 +45,9 @@
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "installYarnUsingApt": false,
+    },
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
   },
   "hostRequirements": {


### PR DESCRIPTION
When using the `ghcr.io/devcontainers/features/node:1` feature, the devcontainer build fails during Yarn installation via APT due to a missing or invalid GPG key:

```
W: OpenPGP signature verification failed:
https://dl.yarnpkg.com/debian stable InRelease:
Sub-process /usr/bin/sqv returned an error code (1),
error message is:
Missing key FF7CB5667B542092084BBDC562D54FD4003F6525

E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

This breaks container builds.

### Fix
- Disabled Yarn installation via APT in the Node feature:
`"installYarnUsingApt": false`

This avoids external repositories, GPG issues and future breakages.