### PR TITLE
feat: run project customize script (.devcontainer/customize.sh) if present

### DIFF
--- a/bin/lifecycle/util/setup-install-on-create.sh
+++ b/bin/lifecycle/util/setup-install-on-create.sh
@@ -33,4 +33,14 @@ else
     notice "WARNING: setup:install failed. Open a terminal and run it manually:
         $SCRIPT_DIR/setup-install.sh | bash"
 fi
+
+# Run user customize script if present (.devcontainer/customize.sh)
+CUSTOMIZE="$(cd "$BIN_DIR/../.." && pwd)/customize.sh"
+if [ -f "$CUSTOMIZE" ]; then
+    notice "Running .devcontainer/customize.sh ..."
+    if ! bash "$CUSTOMIZE"; then
+        notice "WARNING: customize.sh exited with errors — check output above."
+    fi
+fi
+
 exit 0


### PR DESCRIPTION
This modification allows the execution of the `.devcontainer/customize.sh` file, if it exists, after the Magento installation process has been completed.

This will enable us, for example, to run `bin/magento` commands to configure modules installed via Composer, execute importers, set currency settings, and perform other post-installation customizations.

Example `customize.sh`:

#!/bin/bash

cd /workspace

bin/magento config:set twofactorauth/general/enable 0
bin/magento config:set twofactorauth/general/enable_for_api_token_generation 0
bin/magento config:set twofactorauth/general/disable_in_developer_mode 0
bin/magento c:f

